### PR TITLE
Add a simple test program to verify that the hslua bindings actually work

### DIFF
--- a/hslua.cabal
+++ b/hslua.cabal
@@ -1,7 +1,7 @@
 Name:                   hslua
 Version:                0.3.7
 Stability:              beta
-Cabal-version:          >= 1.6
+Cabal-version:          >= 1.8
 License:                BSD3
 Build-type:             Simple
 License-File:           COPYRIGHT
@@ -49,3 +49,9 @@ Library
 
   if os(freebsd)
     CC-Options:         "-DLUA_USE_POSIX"
+
+Test-Suite simple-test
+  type:                 exitcode-stdio-1.0
+  Hs-source-dirs:       test
+  main-is:              simple-test.hs
+  Build-depends:	base, hslua

--- a/test/simple-test.hs
+++ b/test/simple-test.hs
@@ -1,0 +1,8 @@
+import qualified Scripting.Lua as Lua
+
+main :: IO ()
+main = do
+     l <- Lua.newstate
+     Lua.openlibs l
+     Lua.callproc l "print" "Hello from Lua"
+     Lua.close l


### PR DESCRIPTION
When linking against the system's lua library, it's possible that the
hslua library is broken (despite the fact that build succeeds) because
the system's lua shared library lacks certain symbols, i.e.:

  HShslua-0.3.7.o: unknown symbol `lua_neutralize_longjmp'

The included test program catches those issues.
