### PR TITLE
tostring support for strings with \NUL characters

### DIFF
--- a/src/Scripting/Lua.hs
+++ b/src/Scripting/Lua.hs
@@ -491,6 +491,7 @@ tostring l n = do
   lenPtr <- malloc
   cstr <- c_lua_tolstring l (fromIntegral n) lenPtr
   len <- F.peek lenPtr
+  free lenPtr
   peekCStringLen (cstr, fromIntegral len)
 
 -- | See @lua_tothread@ in Lua Reference Manual.


### PR DESCRIPTION
While `pushstring` supports strings with embedded \NUL characters, `tostring` does not. This means that we can push "A\NULB" and then peek to get "A" which is incorrect behaviour. This patch fixes that behaviour.
