### PR TITLE
Fix Windows/ghci specific issue.

### DIFF
--- a/hslua.cabal
+++ b/hslua.cabal
@@ -58,6 +58,9 @@ Library
   if os(freebsd)
     CC-Options:         "-DLUA_USE_POSIX"
 
+  if os(windows)
+     CC-options:        "-D__NO_ISOCEXT"
+    
   if flag(apicheck)
     CC-Options:         "-DLUA_USE_APICHECK"
 


### PR DESCRIPTION
```
unknown symbol '___strtod'`
```

Solution was to add a gcc compile flag
as specified in:

[StackOverflow item](http://stackoverflow.com/questions/11907922/linking-error-using-hslua-on-windows)
