### PR TITLE
docs: add missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Expose a Haskell function to Lua and call it from Lua.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 import Control.Monad (void)
+import Data.Version (makeVersion)
 import HsLua
 import Prelude
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ Expose a Haskell function to Lua and call it from Lua.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 import Control.Monad (void)
+import Data.Version (makeVersion)
 import HsLua
 import Prelude
 


### PR DESCRIPTION
When trying to follow the docs, I noticed a missing import of `Data.Version`.

Side note: I don't know how the readme on the Hackage page (https://hackage.haskell.org/package/hslua) is generated, but it seems out of sync as well. That was actually my first stop when reading about this package, but there doesn't seem to be a `Foreign.Lua` (anymore?).