### PR TITLE
ghc 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,23 +58,33 @@ jobs:
             lua: '5.4.4'
             flags: '+system-lua'
             aeson: '>= 2'
-          - ghc: '9.2.5'
+          - ghc: '9.2'
             cabal: '3.6.2'
             lua: 'bundled'
             flags: '+apicheck'
             aeson: '>= 2'
-          - ghc: '9.4.4'
+          - ghc: '9.4'
             cabal: '3.8'
+            lua: 'bundled'
+            flags: '+apicheck'
+            aeson: '>= 2'
+          - ghc: '9.6'
+            cabal: '3.10'
+            lua: 'bundled'
+            flags: '+apicheck'
+            aeson: '>= 2'
+          - ghc: '9.8'
+            cabal: '3.10'
             lua: 'bundled'
             flags: '+apicheck'
             aeson: '>= 2'
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: ${{ matrix.versions.ghc }}
         cabal-version: ${{ matrix.versions.cabal }}
@@ -115,7 +125,7 @@ jobs:
     name: Windows (stack)
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache stack global package db
         id:   stack-global-package-db

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up HLint
-        uses: haskell/actions/hlint-setup@v2
+        uses: haskell-actions/hlint-setup@v2
 
       - name: Run HLint
-        uses: haskell/actions/hlint-run@v2
+        uses: haskell-actions/hlint-run@v2
         with:
           path: '.'
           fail-on: warning

--- a/hslua-aeson/hslua-aeson.cabal
+++ b/hslua-aeson/hslua-aeson.cabal
@@ -18,8 +18,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-aeson/hslua-aeson.cabal
+++ b/hslua-aeson/hslua-aeson.cabal
@@ -29,16 +29,16 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base                 >= 4.11   && < 5
-                     , aeson                >= 1.5    && < 2.2
-                     , bytestring           >= 0.10.2 && < 0.12
-                     , containers           >= 0.5.9  && < 0.7
+                     , aeson                >= 1.5    && < 2.3
+                     , bytestring           >= 0.10.2 && < 0.13
+                     , containers           >= 0.5.9  && < 0.8
                      , hashable             >= 1.2    && < 1.5
                      , hslua-core           >= 2.0    && < 2.4
                      , hslua-marshalling    >= 2.1    && < 2.4
                      , mtl                  >= 2.2    && < 2.4
                      , scientific           >= 0.3    && < 0.4
                      , unordered-containers >= 0.2    && < 0.3
-                     , text                 >= 1.2    && < 2.1
+                     , text                 >= 1.2    && < 2.2
                      , vector               >= 0.7
   default-extensions:  BangPatterns
                      , CPP

--- a/hslua-classes/hslua-classes.cabal
+++ b/hslua-classes/hslua-classes.cabal
@@ -22,8 +22,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-classes/hslua-classes.cabal
+++ b/hslua-classes/hslua-classes.cabal
@@ -33,12 +33,12 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base              >= 4.11   && < 5
-                     , bytestring        >= 0.10.2 && < 0.12
-                     , containers        >= 0.5.9  && < 0.7
+                     , bytestring        >= 0.10.2 && < 0.13
+                     , containers        >= 0.5.9  && < 0.8
                      , exceptions        >= 0.8    && < 0.11
                      , hslua-core        >= 2.1    && < 2.4
                      , hslua-marshalling >= 2.1    && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/hslua-cli/hslua-cli.cabal
+++ b/hslua-cli/hslua-cli.cabal
@@ -22,8 +22,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-cli/hslua-cli.cabal
+++ b/hslua-cli/hslua-cli.cabal
@@ -62,7 +62,7 @@ library
                      , hslua-marshalling >= 2.2    && < 2.4
                      , hslua-repl        >= 0.1    && < 0.2
                      , lua               >= 2.3    && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
   if !os(windows)
     build-depends:     unix              >= 2.7    && < 2.9
   if os(windows)

--- a/hslua-core/hslua-core.cabal
+++ b/hslua-core/hslua-core.cabal
@@ -36,11 +36,11 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base          >= 4.11   && < 5
-                     , bytestring    >= 0.10.2 && < 0.12
+                     , bytestring    >= 0.10.2 && < 0.13
                      , exceptions    >= 0.8    && < 0.11
                      , lua           >= 2.3.1  && < 2.4
                      , mtl           >= 2.2    && < 2.4
-                     , text          >= 1.2    && < 2.1
+                     , text          >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/hslua-core/hslua-core.cabal
+++ b/hslua-core/hslua-core.cabal
@@ -26,8 +26,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-list/hslua-list.cabal
+++ b/hslua-list/hslua-list.cabal
@@ -20,8 +20,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-marshalling/hslua-marshalling.cabal
+++ b/hslua-marshalling/hslua-marshalling.cabal
@@ -25,8 +25,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-marshalling/hslua-marshalling.cabal
+++ b/hslua-marshalling/hslua-marshalling.cabal
@@ -36,11 +36,11 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base              >= 4.11   && < 5
-                     , bytestring        >= 0.10.2 && < 0.12
-                     , containers        >= 0.5.9  && < 0.7
+                     , bytestring        >= 0.10.2 && < 0.13
+                     , containers        >= 0.5.9  && < 0.8
                      , hslua-core        >= 2.2.1  && < 2.4
                      , mtl               >= 2.2    && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/hslua-module-path/hslua-module-path.cabal
+++ b/hslua-module-path/hslua-module-path.cabal
@@ -31,11 +31,11 @@ source-repository head
 
 common common-options
   build-depends:       base              >= 4.9.1  && < 5
-                     , filepath          >= 1.4    && < 1.5
+                     , filepath          >= 1.4    && < 1.6
                      , hslua-core        >= 2.1    && < 2.4
                      , hslua-marshalling >= 2.1    && < 2.4
                      , hslua-packaging   >= 2.3    && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
 
   ghc-options:         -Wall
                        -Wcompat

--- a/hslua-module-path/hslua-module-path.cabal
+++ b/hslua-module-path/hslua-module-path.cabal
@@ -21,8 +21,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-module-system/hslua-module-system.cabal
+++ b/hslua-module-system/hslua-module-system.cabal
@@ -24,8 +24,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.3
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:              git

--- a/hslua-module-system/hslua-module-system.cabal
+++ b/hslua-module-system/hslua-module-system.cabal
@@ -37,7 +37,7 @@ common common-options
   build-depends:       base                 >= 4.11   && < 5
                      , hslua-core           >= 2.1    && < 2.4
                      , hslua-packaging      >= 2.3    && < 2.4
-                     , text                 >= 1.2    && < 2.1
+                     , text                 >= 1.2    && < 2.2
   default-extensions:  LambdaCase
                      , OverloadedStrings
   ghc-options:         -Wall

--- a/hslua-module-text/hslua-module-text.cabal
+++ b/hslua-module-text/hslua-module-text.cabal
@@ -35,7 +35,7 @@ common common-options
   build-depends:       base                 >= 4.11   && < 5
                      , hslua-core           >= 2.3    && < 2.4
                      , hslua-packaging      >= 2.3    && < 2.4
-                     , text                 >= 1.2    && < 2.1
+                     , text                 >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/hslua-module-text/hslua-module-text.cabal
+++ b/hslua-module-text/hslua-module-text.cabal
@@ -22,8 +22,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.3
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:              git

--- a/hslua-module-version/hslua-module-version.cabal
+++ b/hslua-module-version/hslua-module-version.cabal
@@ -30,11 +30,11 @@ source-repository head
 
 common common-options
   build-depends:       base              >= 4.9.1  && < 5
-                     , filepath          >= 1.4    && < 1.5
+                     , filepath          >= 1.4    && < 1.6
                      , hslua-core        >= 2.3    && < 2.4
                      , hslua-marshalling >= 2.3    && < 2.4
                      , hslua-packaging   >= 2.3    && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
 
   ghc-options:         -Wall
                        -Wcompat

--- a/hslua-module-version/hslua-module-version.cabal
+++ b/hslua-module-version/hslua-module-version.cabal
@@ -20,8 +20,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-module-zip/hslua-module-zip.cabal
+++ b/hslua-module-zip/hslua-module-zip.cabal
@@ -32,13 +32,13 @@ source-repository head
 common common-options
   build-depends:       base              >= 4.11   && < 5
                      , bytestring
-                     , filepath          >= 1.4    && < 1.5
+                     , filepath          >= 1.4    && < 1.6
                      , hslua-core        >= 2.3    && < 2.4
                      , hslua-list        >= 1.1    && < 1.2
                      , hslua-marshalling >= 2.3    && < 2.4
                      , hslua-packaging   >= 2.3    && < 2.4
                      , hslua-typing      >= 0.1    && < 0.2
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
                      , time              >= 1.5    && < 1.14
                      , zip-archive       >= 0.4    && < 0.5
 

--- a/hslua-module-zip/hslua-module-zip.cabal
+++ b/hslua-module-zip/hslua-module-zip.cabal
@@ -21,8 +21,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-objectorientation/hslua-objectorientation.cabal
+++ b/hslua-objectorientation/hslua-objectorientation.cabal
@@ -20,8 +20,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-objectorientation/hslua-objectorientation.cabal
+++ b/hslua-objectorientation/hslua-objectorientation.cabal
@@ -31,14 +31,14 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base              >= 4.11   && < 5
-                     , bytestring        >= 0.10.2 && < 0.12
-                     , containers        >= 0.5.9  && < 0.7
+                     , bytestring        >= 0.10.2 && < 0.13
+                     , containers        >= 0.5.9  && < 0.8
                      , exceptions        >= 0.8    && < 0.11
                      , hslua-core        >= 2.2.1  && < 2.4
                      , hslua-marshalling >= 2.2.1  && < 2.4
                      , hslua-typing      >= 0.1    && < 0.2
                      , mtl               >= 2.2    && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/hslua-packaging/hslua-packaging.cabal
+++ b/hslua-packaging/hslua-packaging.cabal
@@ -23,8 +23,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.3
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-packaging/hslua-packaging.cabal
+++ b/hslua-packaging/hslua-packaging.cabal
@@ -39,7 +39,7 @@ common common-options
                      , hslua-objectorientation >= 2.3    && < 2.4
                      , hslua-typing            >= 0.1    && < 0.2
                      , mtl                     >= 2.2    && < 2.4
-                     , text                    >= 1.2    && < 2.1
+                     , text                    >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances
@@ -68,7 +68,7 @@ library
                      , StrictData
   other-extensions:    DeriveFunctor
                      , OverloadedStrings
-  build-depends:       containers              >= 0.5.9    && < 0.7
+  build-depends:       containers              >= 0.5.9    && < 0.8
 
 test-suite test-hslua-packaging
   import:              common-options

--- a/hslua-repl/hslua-repl.cabal
+++ b/hslua-repl/hslua-repl.cabal
@@ -34,7 +34,7 @@ Flag executable
 common common-options
   build-depends:       base              >= 4.9.1  && < 5
                      , hslua-core        >= 2.3.1  && < 2.4
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
 
   ghc-options:         -Wall
                        -Wcpp-undef
@@ -62,7 +62,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     HsLua.REPL
   build-depends:       base              >= 4.11   && < 5
-                     , bytestring        >= 0.10   && < 0.12
+                     , bytestring        >= 0.10   && < 0.13
                      , isocline          >= 1.0    && < 1.1
                      , lua               >= 2.3    && < 2.4
 

--- a/hslua-repl/hslua-repl.cabal
+++ b/hslua-repl/hslua-repl.cabal
@@ -19,8 +19,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-typing/hslua-typing.cabal
+++ b/hslua-typing/hslua-typing.cabal
@@ -18,8 +18,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua-typing/hslua-typing.cabal
+++ b/hslua-typing/hslua-typing.cabal
@@ -54,10 +54,10 @@ library
   import:              common-options
   exposed-modules:     HsLua.Typing
   hs-source-dirs:      src
-  build-depends:       containers           >= 0.5.9  && < 0.7
+  build-depends:       containers           >= 0.5.9  && < 0.8
                      , hslua-core           >= 2.3    && < 2.4
                      , hslua-marshalling    >= 2.3    && < 2.4
-                     , text                 >= 1.2    && < 2.1
+                     , text                 >= 1.2    && < 2.2
   default-language:    Haskell2010
 
 test-suite test-hslua-typing

--- a/hslua/hslua.cabal
+++ b/hslua/hslua.cabal
@@ -30,8 +30,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/hslua/hslua.cabal
+++ b/hslua/hslua.cabal
@@ -40,8 +40,8 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base                    >= 4.11  && < 5
-                     , bytestring              >= 0.10.2 && < 0.12
-                     , containers              >= 0.5.9  && < 0.7
+                     , bytestring              >= 0.10.2 && < 0.13
+                     , containers              >= 0.5.9  && < 0.8
                      , exceptions              >= 0.8    && < 0.11
                      , hslua-aeson             >= 2.3    && < 2.4
                      , hslua-core              >= 2.3    && < 2.4
@@ -51,7 +51,7 @@ common common-options
                      , hslua-packaging         >= 2.3    && < 2.4
                      , hslua-typing            >= 0.1    && < 0.2
                      , mtl                     >= 2.2    && < 2.4
-                     , text                    >= 1.2    && < 2.1
+                     , text                    >= 1.2    && < 2.2
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/lpeg/lpeg.cabal
+++ b/lpeg/lpeg.cabal
@@ -25,8 +25,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/lua-arbitrary/lua-arbitrary.cabal
+++ b/lua-arbitrary/lua-arbitrary.cabal
@@ -22,8 +22,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/lua/lua.cabal
+++ b/lua/lua.cabal
@@ -28,8 +28,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/tasty-hslua/tasty-hslua.cabal
+++ b/tasty-hslua/tasty-hslua.cabal
@@ -31,7 +31,7 @@ common common-options
   default-language:    Haskell2010
   build-depends:       base          >= 4.11   && < 5
                      , hslua-core    >= 2.3    && < 2.4
-                     , bytestring    >= 0.10.2 && < 0.12
+                     , bytestring    >= 0.10.2 && < 0.13
   ghc-options:         -Wall
                        -Wincomplete-record-updates
                        -Wnoncanonical-monad-instances

--- a/tasty-hslua/tasty-hslua.cabal
+++ b/tasty-hslua/tasty-hslua.cabal
@@ -20,8 +20,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:                git

--- a/tasty-lua/tasty-lua.cabal
+++ b/tasty-lua/tasty-lua.cabal
@@ -19,8 +19,10 @@ tested-with:         GHC == 8.4.4
                    , GHC == 8.8.3
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.5
-                   , GHC == 9.4.4
+                   , GHC == 9.2.8
+                   , GHC == 9.4.8
+                   , GHC == 9.6.3
+                   , GHC == 9.8.1
 
 source-repository head
   type:              git

--- a/tasty-lua/tasty-lua.cabal
+++ b/tasty-lua/tasty-lua.cabal
@@ -30,11 +30,11 @@ source-repository head
 common common-options
   default-language:    Haskell2010
   build-depends:       base              >= 4.11   && < 5
-                     , bytestring        >= 0.10.2 && < 0.12
+                     , bytestring        >= 0.10.2 && < 0.13
                      , hslua-core        >= 2.3    && < 2.4
                      , hslua-marshalling >= 2.0    && < 2.4
                      , lua-arbitrary     >= 1.0    && < 1.1
-                     , tasty             >= 1.2    && < 1.5
+                     , tasty             >= 1.2    && < 1.6
                      , QuickCheck        >= 2.9    && < 2.15
   default-extensions:  LambdaCase
                      , StrictData
@@ -54,7 +54,7 @@ common common-options
 library
   import:              common-options
   build-depends:       file-embed        >= 0.0    && < 0.1
-                     , text              >= 1.2    && < 2.1
+                     , text              >= 1.2    && < 2.2
   exposed-modules:     Test.Tasty.Lua
                      , Test.Tasty.Lua.Arbitrary
                      , Test.Tasty.Lua.Core


### PR DESCRIPTION
- Bump CI, aeson, bytestring, containers, filepath, tasty, text
- Bump tested-with field to latest GHC major versions (9.8.1)
