### PR TITLE
fix(lua): export all lua symbols on macos

### DIFF
--- a/lua/lua.cabal
+++ b/lua/lua.cabal
@@ -195,6 +195,8 @@ library
 
   if os(darwin)
     cc-options:          -DLUA_USE_MACOSX
+    if flag(export-dynamic)
+      ld-options:        -Wl,-export_dynamic
 
   if os(freebsd)
     cc-options:          -DLUA_USE_POSIX


### PR DESCRIPTION
This PR fixes an issue where some lua symbols were not visible on macOS, causing errors when loading compiled modules. See the pandoc issue here: https://github.com/jgm/pandoc/issues/11587

The linker flag in question is not documented in any official capacity, at least from what I could find. It was suggested by Claude after some lengthy debugging. Researching the flag, I came across a [postgres mailing list thread](https://www.postgresql.org/message-id/flat/427c7c25-e8e1-4fc5-a1fb-01ceff185e5b%40technowledgy.de), a [meson bug report](https://github.com/mesonbuild/meson/issues/13543), and a [wayback machine snapshot of some no-longer-published apple documentation](https://web.archive.org/web/20240712104928/https://opensource.apple.com/source/ld64/ld64-609/doc/man/man1/ld.1.auto.html). All indicate that this flag serves a similar purpose as the linux/freebsd `export-dynamic` flag. 

I've tested this on macOS 26, building pandoc from source and directing it to use my fork. The symbols now seem appropriately exported, as loading my module succeeds! 

I also tested to see if the issue was present on linux, but I could not reproduce it with a non-static build through the fedora repo. I also tested applying the flags to the pandoc binary, but that did not have any impact.

For consideration, this flag does not work on versions of macOS older than 10.7 (Lion), as mentioned in the meson issue, but that is quite an old version and probably not relevant in this instance.