### PR TITLE
chore: make `export_dynamic` the default for macOS builds

### DIFF
--- a/lua/lua.cabal
+++ b/lua/lua.cabal
@@ -195,8 +195,7 @@ library
 
   if os(darwin)
     cc-options:          -DLUA_USE_MACOSX
-    if flag(export-dynamic)
-      ld-options:        -Wl,-export_dynamic
+    ld-options:          -Wl,-export_dynamic
 
   if os(freebsd)
     cc-options:          -DLUA_USE_POSIX


### PR DESCRIPTION
This PR is a follow-up to #159, making the new macOS `ld-options` the default build options.