### PR TITLE
Add filesystem metadata helpers to hslua-module-system

### DIFF
--- a/hslua-module-system/CHANGELOG.md
+++ b/hslua-module-system/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 `hslua-module-system` uses [PVP Versioning][].
 
+## hslua-module-system-1.3.1
+
+Released pending.
+
+- Added new functions `stat` and `ls_with_metadata`, which return
+  file metadata such as type, size, permissions, access time, and
+  modification time.
+
 ## hslua-module-system-1.3.0
 
 Released 2026-01-08.

--- a/hslua-module-system/README.md
+++ b/hslua-module-system/README.md
@@ -145,6 +145,23 @@ Returns:
 - A table of all entries in `directory` without the special entries (`.`
   and `..`).
 
+#### ls_with_metadata
+
+`ls_with_metadata ([directory])`
+
+List the contents of a directory and include file metadata for each
+entry.
+
+Parameters:
+
+`directory`
+:   Path of the directory whose contents should be listed (string).
+    Defaults to `.`.
+
+Returns:
+
+- A table of entries in `directory`, with file metadata for each entry.
+
 #### mkdir
 
 `mkdir (dirname [, create_parent])`
@@ -207,6 +224,22 @@ Parameters:
 `directory`
 :   Path of the directory which is to become the new working
     directory (string)
+
+#### stat
+
+`stat (filepath)`
+
+Obtain metadata for a file or directory. The returned table contains
+the path, type, size, permissions, access time, and modification time.
+
+Parameters:
+
+`filepath`
+:   file or directory path (string)
+
+Returns:
+
+- file metadata (table)
 
 #### tmpdirname
 

--- a/hslua-module-system/hslua-module-system.cabal
+++ b/hslua-module-system/hslua-module-system.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                hslua-module-system
-version:             1.3.0
+version:             1.3.1
 synopsis:            Lua module wrapper around Haskell's System module.
 
 description:         Provides access to system information and
@@ -58,6 +58,7 @@ library
   build-depends:       bytestring           >= 0.10.2 && < 0.13
                      , directory            >= 1.3.2  && < 1.4
                      , exceptions           >= 0.8    && < 0.11
+                     , filepath             >= 1.4    && < 1.6
                      , hslua-list           >= 1.1    && < 1.2
                      , hslua-marshalling    >= 2.1    && < 2.4
                      , process              >= 1.2.3  && < 1.7

--- a/hslua-module-system/src/HsLua/Module/System.hs
+++ b/hslua-module-system/src/HsLua/Module/System.hs
@@ -29,6 +29,7 @@ module HsLua.Module.System (
   , getenv
   , getwd
   , ls
+  , ls_with_metadata
   , mkdir
   , read_file
   , rename
@@ -36,6 +37,7 @@ module HsLua.Module.System (
   , rmdir
   , setenv
   , setwd
+  , stat
   , times
   , tmpdirname
   , with_env
@@ -66,6 +68,7 @@ import qualified System.CPUTime as CPUTime
 import qualified System.Directory as Directory
 import qualified System.Environment as Env
 import qualified System.Exit as Exit
+import qualified System.FilePath as FilePath
 import qualified System.Info as Info
 import qualified System.IO.Temp as Temp
 import qualified System.Process as Process
@@ -89,6 +92,7 @@ documentedModule = defmodule "system"
       , getenv
       , getwd
       , ls
+      , ls_with_metadata
       , mkdir
       , read_file
       , rename
@@ -96,6 +100,7 @@ documentedModule = defmodule "system"
       , rmdir
       , setenv
       , setwd
+      , stat
       , times
       , tmpdirname
       , with_env
@@ -290,6 +295,25 @@ ls = defun "ls"
           `T.append` "special entries (`.`  and `..`).")
   #? "List the contents of a directory."
 
+-- | List the contents of a directory with file metadata.
+ls_with_metadata :: LuaError e => DocumentedFunction e
+ls_with_metadata = defun "ls_with_metadata"
+  ### (\mdir -> do
+          let dir = fromMaybe "." mdir
+          ioToLua $ do
+            names <- Directory.listDirectory dir
+            traverse (\name -> getFileMetadata name (dir FilePath.</> name))
+              names)
+  <#> opt (filepathParam "directory"
+           ("Path of the directory whose contents should be listed. "
+            `T.append` "Defaults to `.`."))
+  =#> functionResult (pushList pushFileMetadata) "table"
+        ("A table of entries in `directory`, with file metadata for "
+         `T.append` "each entry.")
+  #? T.unlines
+     [ "List the contents of a directory and include file metadata for"
+     , "each entry."
+     ]
 
 -- | Create a new directory which is initially empty, or as near to
 -- empty as the operating system allows.
@@ -390,6 +414,19 @@ setwd = defun "setwd"
   <#> filepathParam "directory" "Path of the new working directory"
   =#> []
   #? "Change the working directory to the given path."
+
+-- | Get metadata for a file or directory.
+stat :: LuaError e => DocumentedFunction e
+stat = defun "stat"
+  ### (\filepath -> ioToLua $
+          getFileMetadata (FilePath.takeFileName filepath) filepath)
+  <#> filepathParam "filepath" "file or directory path"
+  =#> functionResult pushFileMetadata "table" "file metadata"
+  #? T.unlines
+     [ "Obtain metadata for a file or directory."
+     , "The returned table contains the path, type, size, permissions,"
+     , "access time, and modification time."
+     ]
 
 -- | Get the modification time and access time of a file.
 times :: LuaError e => DocumentedFunction e
@@ -614,6 +651,75 @@ pushExitCode = \case
 -- | Pushes a time as ISO 8601 string.
 pushUTCTime :: Pusher e Time.UTCTime
 pushUTCTime = pushString . ISO8601.iso8601Show
+
+-- | Metadata for a file system object.
+data FileMetadata = FileMetadata
+  { fileMetadataName             :: FilePath
+  , fileMetadataPath             :: FilePath
+  , fileMetadataType             :: String
+  , fileMetadataSize             :: Maybe Prelude.Integer
+  , fileMetadataModificationTime :: Time.UTCTime
+  , fileMetadataAccessTime       :: Time.UTCTime
+  , fileMetadataPermissions      :: Directory.Permissions
+  , fileMetadataIsSymlink        :: Bool
+  }
+
+-- | Get metadata for a file system object.
+getFileMetadata :: FilePath -> FilePath -> IO FileMetadata
+getFileMetadata name path = do
+  pathExists <- Directory.doesPathExist path
+  isSymlink <- if pathExists
+               then Directory.pathIsSymbolicLink path
+               else pure False
+  isFile <- Directory.doesFileExist path
+  isDirectory <- Directory.doesDirectoryExist path
+  let fileType
+        | isSymlink   = "symlink"
+        | isDirectory = "directory"
+        | isFile      = "file"
+        | otherwise   = "other"
+  size <- if isFile
+          then Just <$> Directory.getFileSize path
+          else pure Nothing
+  modificationTime <- Directory.getModificationTime path
+  accessTime <- Directory.getAccessTime path
+  permissions <- Directory.getPermissions path
+  pure FileMetadata
+    { fileMetadataName = name
+    , fileMetadataPath = path
+    , fileMetadataType = fileType
+    , fileMetadataSize = size
+    , fileMetadataModificationTime = modificationTime
+    , fileMetadataAccessTime = accessTime
+    , fileMetadataPermissions = permissions
+    , fileMetadataIsSymlink = isSymlink
+    }
+
+-- | Push file metadata as a table.
+pushFileMetadata :: LuaError e => Pusher e FileMetadata
+pushFileMetadata = pushAsTable
+  [ ("name", pushString . fileMetadataName)
+  , ("path", pushString . fileMetadataPath)
+  , ("type", pushString . fileMetadataType)
+  , ("size", pushMaybe pushIntegral . fileMetadataSize)
+  , ("modification_time", pushUTCTime . fileMetadataModificationTime)
+  , ("access_time", pushUTCTime . fileMetadataAccessTime)
+  , ("permissions", pushPermissions . fileMetadataPermissions)
+  , ("is_symlink", pushBool . fileMetadataIsSymlink)
+  ]
+
+-- | Push file permissions as a table.
+pushPermissions :: LuaError e => Pusher e Directory.Permissions
+pushPermissions = pushAsTable
+  [ ("readable", pushBool . Directory.readable)
+  , ("writable", pushBool . Directory.writable)
+  , ("executable", pushBool . Directory.executable)
+  , ("searchable", pushBool . Directory.searchable)
+  ]
+
+-- | Push 'Nothing' as nil, or push the contained value.
+pushMaybe :: Pusher e a -> Pusher e (Maybe a)
+pushMaybe pushValue = maybe pushnil pushValue
 
 -- | Get an XDG directory type identifier.
 peekXdgDirectory :: Peeker e

--- a/hslua-module-system/test/test-system.lua
+++ b/hslua-module-system/test/test-system.lua
@@ -160,6 +160,46 @@ return {
     end)
   },
 
+  group 'ls_with_metadata' {
+    test('returns a table', function ()
+      assert.are_equal(type(system.ls_with_metadata('.')), 'table')
+    end),
+    test('lists files with metadata', in_tmpdir(function ()
+      system.write_file('README.org', 'test')
+      local entry = system.ls_with_metadata('.')[1]
+      assert.are_equal(entry.name, 'README.org')
+      assert.is_truthy(entry.path:match 'README%.org$')
+      assert.are_equal(entry.type, 'file')
+      assert.are_equal(entry.size, 4)
+      assert.are_equal(type(entry.modification_time), 'string')
+      assert.are_equal(type(entry.access_time), 'string')
+      assert.are_equal(type(entry.permissions), 'table')
+      assert.are_equal(type(entry.permissions.readable), 'boolean')
+      assert.are_equal(entry.is_symlink, false)
+    end)),
+    test('includes directory metadata', in_tmpdir(function ()
+      system.mkdir 'folder'
+      local entry = system.ls_with_metadata('.')[1]
+      assert.are_equal(entry.name, 'folder')
+      assert.are_equal(entry.type, 'directory')
+      assert.is_nil(entry.size)
+      assert.are_equal(type(entry.permissions.searchable), 'boolean')
+    end)),
+    test('argument defaults to `.`', function ()
+      assert.are_equal(#system.ls_with_metadata('.'), #system.ls_with_metadata())
+    end),
+    test('fails when arg is not a directory', function ()
+      assert.error_matches(
+        function () system.ls_with_metadata('thisdoesnotexist') end,
+        'thisdoesnotexist'
+      )
+      assert.error_matches(
+        function () system.ls_with_metadata('README.md') end,
+        'README%.md'
+      )
+    end)
+  },
+
   group 'mkdir' {
     test('create directory', in_tmpdir(function ()
       system.mkdir 'foo'
@@ -293,6 +333,36 @@ return {
       system.rmdir('outer', true)
       assert.are_same(system.ls(), {})
     end))
+  },
+
+  group 'stat' {
+    test('returns file metadata', in_tmpdir(function ()
+      system.write_file('foo.txt', 'test')
+      local info = system.stat('foo.txt')
+      assert.are_equal(info.name, 'foo.txt')
+      assert.are_equal(info.path, 'foo.txt')
+      assert.are_equal(info.type, 'file')
+      assert.are_equal(info.size, 4)
+      assert.are_equal(type(info.modification_time), 'string')
+      assert.are_equal(type(info.access_time), 'string')
+      assert.are_equal(type(info.permissions), 'table')
+      assert.are_equal(type(info.permissions.writable), 'boolean')
+      assert.are_equal(info.is_symlink, false)
+    end)),
+    test('returns directory metadata', in_tmpdir(function ()
+      system.mkdir 'folder'
+      local info = system.stat('folder')
+      assert.are_equal(info.name, 'folder')
+      assert.are_equal(info.type, 'directory')
+      assert.is_nil(info.size)
+      assert.are_equal(type(info.permissions.searchable), 'boolean')
+    end)),
+    test('fails if path does not exist', in_tmpdir(function ()
+      assert.error_matches(
+        function () system.stat('does-not-exist.org') end,
+        'does%-not%-exist%.org'
+      )
+    end)),
   },
 
   group 'times' {


### PR DESCRIPTION
This adds two filesystem metadata helpers to `hslua-module-system`:
- `system.stat(path)`: returns metadata for a single file or directory.
- `system.ls_with_metadata([directory])`: lists directory entries together with metadata.

The metadata table includes:
- `name`
- `path`
- `type`
- `size`
- `modification_time`
- `access_time`
- `permissions`
- `is_symlink`

This addresses #145 and provides the HsLua-side functionality needed for jgm/pandoc#9422.

## Notes
`ls` remains unchanged, so existing callers keep receiving a plain list of filenames.

## Testing
- `cabal test hslua-module-system`
- `git diff --check`
- `lua -e 'assert(loadfile("hslua-module-system/test/test-system.lua"))'`